### PR TITLE
Implement hook_uninstall to cleanup variables

### DIFF
--- a/pantheon_secure_login.install
+++ b/pantheon_secure_login.install
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Pantheon Secure Login module installation functions.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function pantheon_secure_login_uninstall() {
+  $variables = array(
+    'pantheon_secure_login_live_domain',
+    'pantheon_secure_login_enabled',
+  );
+
+  foreach ($variables as $variable) {
+    variable_del($variable);
+  }
+}


### PR DESCRIPTION
The module defines 2 variables but doesn't remove then when it is uninstalled.  Modules should clean up after themselves.  This patch implements hook_uninstall() to do the cleanup.
